### PR TITLE
feat: `WripeAPI` uses precision from the `write` call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
       - run: |
           apt-get update
           apt-get install wget unzip --yes
-          wget https://github.com/realm/SwiftLint/releases/download/0.42.0/swiftlint_linux.zip
+          wget https://github.com/realm/SwiftLint/releases/download/0.43.0/swiftlint_linux.zip
           unzip -n swiftlint_linux.zip
           ln -s /root/project/swiftlint /usr/bin/swiftlint
   check-example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.0 [unreleased]
 
 ### API
+1. [#30](https://github.com/influxdata/influxdb-client-swift/pull/30): The writes uses precision from the `write` call
 1. [#28](https://github.com/influxdata/influxdb-client-swift/pull/28): Updated swagger to latest version
 1. [#29](https://github.com/influxdata/influxdb-client-swift/pull/29): Updated `Cursor` API to latest version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 0.3.0 [unreleased]
 
 ### API
-1. [#30](https://github.com/influxdata/influxdb-client-swift/pull/30): The writes uses precision from the `write` call
-1. [#28](https://github.com/influxdata/influxdb-client-swift/pull/28): Updated swagger to latest version
-1. [#29](https://github.com/influxdata/influxdb-client-swift/pull/29): Updated `Cursor` API to latest version
+1. [#30](https://github.com/influxdata/influxdb-client-swift/pull/30): `WripeAPI` uses precision from the `write` call
+1. [#28](https://github.com/influxdata/influxdb-client-swift/pull/28): Update management API to latest version
+1. [#29](https://github.com/influxdata/influxdb-client-swift/pull/29): Update `Cursor` API to latest version
 
 ## 0.2.0 [2021-03-05]
 

--- a/Sources/InfluxDBSwift/QueryAPI.swift
+++ b/Sources/InfluxDBSwift/QueryAPI.swift
@@ -239,7 +239,7 @@ extension QueryAPI {
         /// Description of the type of data contained within the column.
         public let dataType: String
         /// Boolean flag indicating if the column is part of the table's group key
-        public var group: Bool = false
+        public var group = false
         /// Default value to be used for rows whose string value is the empty string.
         public var defaultValue: String = ""
 

--- a/Sources/InfluxDBSwift/WriteAPI.swift
+++ b/Sources/InfluxDBSwift/WriteAPI.swift
@@ -693,10 +693,9 @@ public class WriteAPI {
                                 point: InfluxDBClient.Point,
                                 defaultTags: [String: String?]?,
                                 batches: inout [InfluxDBClient.TimestampPrecision: (Int, [String])]) throws {
-        if let lineProtocol = try point.toLineProtocol(defaultTags: defaultTags) {
-            let pointPrecision = point.time?.precision ?? InfluxDBClient.defaultTimestampPrecision
+        if let lineProtocol = try point.toLineProtocol(precision: precision, defaultTags: defaultTags) {
             return try toLineProtocol(
-                    precision: pointPrecision,
+                    precision: precision,
                     record: lineProtocol,
                     defaultTags: defaultTags,
                     batches: &batches)

--- a/Tests/InfluxDBSwiftTests/WriteAPITests.swift
+++ b/Tests/InfluxDBSwiftTests/WriteAPITests.swift
@@ -426,6 +426,26 @@ final class WriteAPITests: XCTestCase {
         XCTAssertEqual(required, body.joined(separator: "\n"))
     }
 
+    func testEmptyRecords() {
+        let expectation = self.expectation(description: "Success response from API doesn't arrive")
+
+        MockURLProtocol.handler = { _, _ in
+            XCTFail("unexpected HTTP call")
+
+            let response = HTTPURLResponse(statusCode: 204)
+            return (response, Data())
+        }
+
+        client.makeWriteAPI().write(records: ["", ""]) { _, error in
+            if let error = error {
+                XCTFail("Error occurs: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
     private func simpleWriteHandler(expectation: XCTestExpectation) -> (URLRequest, Data?)
     -> (HTTPURLResponse, Data) {
         { request, bodyData in

--- a/Tests/InfluxDBSwiftTests/WriteAPITests.swift
+++ b/Tests/InfluxDBSwiftTests/WriteAPITests.swift
@@ -83,7 +83,7 @@ final class WriteAPITests: XCTestCase {
 
     func testWritePointsDifferentPrecision() {
         let expectation = self.expectation(description: "Success response from API doesn't arrive")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 2
 
         var requests: [URLRequest] = []
         var bodies: [String] = []
@@ -112,16 +112,12 @@ final class WriteAPITests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
 
-        XCTAssertEqual(2, requests.count)
-        XCTAssertEqual(
-                "\(Self.dbURL())/api/v2/write?bucket=my-bucket&org=my-org&precision=s",
-                requests[0].url?.description)
+        XCTAssertEqual(1, requests.count)
         XCTAssertEqual(
                 "\(Self.dbURL())/api/v2/write?bucket=my-bucket&org=my-org&precision=ns",
-                requests[1].url?.description)
-        XCTAssertEqual(2, bodies.count)
-        XCTAssertEqual("mem,tag=a value=1i 1", bodies[0])
-        XCTAssertEqual("mem,tag=b value=2i 2", bodies[1])
+                requests[0].url?.description)
+        XCTAssertEqual(1, bodies.count)
+        XCTAssertEqual("mem,tag=a value=1i 1000000000\nmem,tag=b value=2i 2", bodies[0])
     }
 
     func testWriteArrayOfArray() {


### PR DESCRIPTION
Closes #27 

## Proposed Changes

Writes uses precision specified in `write` call.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `swift test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
