### PR TITLE
fix: add missing PermissionResource types from Cloud definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
           name: Install Maven & Curl
           command: |
             apt-get update
-            apt-get install maven curl --yes
+            apt-get install maven curl wget --yes
       - run:
           name: Checks generating sources from swagger
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ SourceKitten/
 # Junit
 junit.xml
 tests.xml
+
+Scripts/cloud.yml
+Scripts/oss.yml
+Scripts/influxdb-clients-apigen/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.0.0 [unreleased]
 
+### Bug Fixes
+1. [#46](https://github.com/influxdata/influxdb-client-swift/pull/46): Add missing PermissionResources from Cloud API definition
+
 ## 0.9.0 [2021-11-26]
 
 ### Documentation

--- a/Scripts/generate-sources.sh
+++ b/Scripts/generate-sources.sh
@@ -15,7 +15,7 @@ rm -rf "${SCRIPT_PATH}"/cloud.yml || true
 rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true
 wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml -O "${SCRIPT_PATH}/oss.yml"
 wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/cloud.yml -O "${SCRIPT_PATH}/cloud.yml"
-git clone --single-branch --branch permission_type_from_cloud https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
+git clone --single-branch --branch master https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
 mvn -f "$SCRIPT_PATH"/influxdb-clients-apigen/openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="$SCRIPT_PATH/oss.yml $SCRIPT_PATH/cloud.yml"
 
 # Generate client

--- a/Scripts/generate-sources.sh
+++ b/Scripts/generate-sources.sh
@@ -9,7 +9,7 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 
 rm -rf "${SCRIPT_PATH}"/generated
 
-# Download and match OSS and Cloud definition
+# Download and merge OSS and Cloud definition
 rm -rf "${SCRIPT_PATH}"/oss.yml || true
 rm -rf "${SCRIPT_PATH}"/cloud.yml || true
 rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true

--- a/Scripts/generate-sources.sh
+++ b/Scripts/generate-sources.sh
@@ -2,12 +2,21 @@
 
 #
 # How to run script from ROOT path:
-#   docker run --rm -it -v "${PWD}":/code -v ~/.m2:/root/.m2 -w /code maven:3.6-slim /code/Scripts/generate-sources.sh
+#   docker run --rm -it -v "${PWD}":/code -v ~/.m2:/root/.m2 -w /code maven:3-openjdk-8 /code/Scripts/generate-sources.sh
 #
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 
 rm -rf "${SCRIPT_PATH}"/generated
+
+# Download and match OSS and Cloud definition
+rm -rf "${SCRIPT_PATH}"/oss.yml || true
+rm -rf "${SCRIPT_PATH}"/cloud.yml || true
+rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true
+wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml -O "${SCRIPT_PATH}/oss.yml"
+wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/cloud.yml -O "${SCRIPT_PATH}/cloud.yml"
+git clone --single-branch --branch permission_type_from_cloud https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
+mvn -f "$SCRIPT_PATH"/influxdb-clients-apigen/openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="$SCRIPT_PATH/oss.yml $SCRIPT_PATH/cloud.yml"
 
 # Generate client
 cd "${SCRIPT_PATH}"/ || exit

--- a/Scripts/pom.xml
+++ b/Scripts/pom.xml
@@ -14,7 +14,7 @@
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <version>5.1.0</version>
                 <configuration>
-                    <inputSpec>https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml</inputSpec>
+                    <inputSpec>./oss.yml</inputSpec>
                     <generatorName>swift5</generatorName>
                     <configOptions>
                         <projectName>InfluxDB2</projectName>

--- a/Sources/InfluxDBSwiftApis/Generated/Models/Resource.swift
+++ b/Sources/InfluxDBSwiftApis/Generated/Models/Resource.swift
@@ -29,6 +29,11 @@ public struct Resource: Codable {
         case checks = "checks"
         case dbrp = "dbrp"
         case notebooks = "notebooks"
+        case annotations = "annotations"
+        case remotes = "remotes"
+        case replications = "replications"
+        case flows = "flows"
+        case functions = "functions"
     }
     public var type: ModelType
     /** If ID is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type. */


### PR DESCRIPTION
## Proposed Changes

Added missing `PermissionResource` types.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `swift test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
