### PR TITLE
feat: add FluxRecord.row with response data stored in Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.5.0 [unreleased]
 
+### Features
+1. [#57](https://github.com/influxdata/influxdb-client-swift/pull/57): Added `FluxRecord.row` which stores response data in a array
+
 ## 1.4.0 [2022-09-30]
 
 ### CI

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -16,4 +16,5 @@
 - [AsyncAwait](AsyncAwait#asyncawait) - How to use `async/await` with the InfluxDB client.
 - [InfluxDBStatus](InfluxDBStatus#influxdbstatus) - This is an example how to check status of InfluxDB
 - [InvokableScripts](InvokableScripts#invokablescripts) - How to use Invokable scripts Cloud API to create custom endpoints that query data
-  
+- [RecordRow](RecordRow#recordrow) - How to use `FluxRecord.row` instead of `FluxRecord.values`,
+  in case of duplicity column names  

--- a/Examples/RecordRow/.swiftlint.yml
+++ b/Examples/RecordRow/.swiftlint.yml
@@ -1,0 +1,36 @@
+opt_in_rules:
+  - array_init
+  - collection_alignment
+  - contains_over_first_not_nil
+  - closure_end_indentation
+  - closure_spacing
+  - conditional_returns_on_newline
+  - empty_count
+  - empty_string
+  - explicit_init
+  - explicit_self
+  - fatal_error_message
+  - first_where
+  - implicit_return
+  - missing_docs
+  - modifier_order
+  - multiline_arguments
+  - multiline_literal_brackets
+  - multiline_parameters
+  - operator_usage_whitespace
+  - pattern_matching_keywords
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - sorted_first_last
+  - sorted_imports
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - unused_import
+  - unused_declaration
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+
+excluded:
+  - Package.swift
+  - .build/

--- a/Examples/RecordRow/Package.swift
+++ b/Examples/RecordRow/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+        name: "RecordRow",
+        platforms: [
+            .macOS(.v10_15)
+        ],
+        products: [
+            .executable(name: "record-row", targets: ["RecordRow"])
+        ],
+        dependencies: [
+            .package(name: "influxdb-client-swift", path: "../../"),
+            .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.2")
+        ],
+        targets: [
+            .executableTarget(name: "RecordRow", dependencies: [
+                .product(name: "InfluxDBSwiftApis", package: "influxdb-client-swift"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ])
+        ]
+)

--- a/Examples/RecordRow/README.md
+++ b/Examples/RecordRow/README.md
@@ -50,19 +50,19 @@ Using 'FluxRecord.row' in case of duplicated column names in response.
 ## Expected output
 
 ```bash
-The response contains columns with duplicated names: table, result 
+The response contains columns with duplicated names: table, result
 You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values' dictionary.
 ------------------------------------------ FluxRecord.values ------------------------------------------
-_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 1.0, table: my-table
-_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 2.0, table: my-table
-_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 3.0, table: my-table
-_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 4.0, table: my-table
-_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 5.0, table: my-table
+_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 1.0, table: my-table
+_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 2.0, table: my-table
+_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 3.0, table: my-table
+_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 4.0, table: my-table
+_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 5.0, table: my-table
 -------------------------------------------- FluxRecord.row -------------------------------------------
-_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 1.0, my-table
-_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 2.0, my-table
-_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 3.0, my-table
-_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 4.0, my-table
-_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 5.0, my-table
+_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(1.0), my-table
+_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(2.0), my-table
+_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(3.0), my-table
+_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(4.0), my-table
+_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(5.0), my-table
 
 ```

--- a/Examples/RecordRow/README.md
+++ b/Examples/RecordRow/README.md
@@ -1,0 +1,68 @@
+# RecordRow
+
+Using 'FluxRecord.row' in case of duplicated column names in response.
+
+## Prerequisites:
+- Docker
+- Cloned examples:
+   ```bash
+   git clone git@github.com:influxdata/influxdb-client-swift.git
+   cd Examples/RecordRow
+   ```
+
+## Sources:
+- [Package.swift](/Examples/RecordRow/Package.swift)
+- [RecordRow.swift](/Examples/RecordRow/Sources/RecordRow/RecordRow.swift)
+
+## How to test:
+1. Start InfluxDB:
+    ```bash
+    docker run --rm \
+      --name influxdb_v2 \
+      --detach \
+      --publish 8086:8086 \
+      influxdb:latest
+    ```
+2. Configure your username, password, organization, bucket and token:
+   ```bash
+   docker run --rm \
+      --link influxdb_v2 \
+      curlimages/curl -s -i -X POST http://influxdb_v2:8086/api/v2/setup \
+         -H 'accept: application/json' \
+         -d '{"username": "my-user", "password": "my-password", "org": "my-org", "bucket": "my-bucket", "token": "my-token"}'
+   ```
+3. Start SwiftCLI by:
+   ```bash
+    docker run --rm \
+      --link influxdb_v2 \
+      --privileged \
+      --interactive \
+      --tty \
+      --volume $PWD/../..:/client \
+      --workdir /client/Examples/RecordRow \
+      swift:5.7 /bin/bash
+   ```
+4. Execute by:
+   ```bash
+   swift run record-row --org my-org --bucket my-bucket --token my-token --url http://influxdb_v2:8086
+   ```
+
+## Expected output
+
+```bash
+The response contains columns with duplicated names: table, result 
+You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values' dictionary.
+------------------------------------------ FluxRecord.values ------------------------------------------
+_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 1.0, table: my-table
+_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 2.0, table: my-table
+_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 3.0, table: my-table
+_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 4.0, table: my-table
+_measurement: point, _start: 2022-10-11 16:38:30 +0000, _stop: 2022-10-11 16:39:30 +0000, _time: 2022-10-11 16:39:30 +0000, result: 5.0, table: my-table
+-------------------------------------------- FluxRecord.row -------------------------------------------
+_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 1.0, my-table
+_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 2.0, my-table
+_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 3.0, my-table
+_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 4.0, my-table
+_result, 0, 2022-10-11 16:38:30 +0000, 2022-10-11 16:39:30 +0000, 2022-10-11 16:39:30 +0000, point, 5.0, my-table
+
+```

--- a/Examples/RecordRow/README.md
+++ b/Examples/RecordRow/README.md
@@ -50,19 +50,19 @@ Using 'FluxRecord.row' in case of duplicated column names in response.
 ## Expected output
 
 ```bash
-The response contains columns with duplicated names: table, result
+The response contains columns with duplicated names: result, table
 You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values' dictionary.
 ------------------------------------------ FluxRecord.values ------------------------------------------
-_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 1.0, table: my-table
-_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 2.0, table: my-table
-_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 3.0, table: my-table
-_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 4.0, table: my-table
-_measurement: point, _start: 2022-10-12 09:24:33 +0000, _stop: 2022-10-12 09:25:33 +0000, _time: 2022-10-12 09:25:33 +0000, result: 5.0, table: my-table
+_measurement: point, _start: 2022-10-13 07:56:08 +0000, _stop: 2022-10-13 07:57:08 +0000, _time: 2022-10-13 07:57:08 +0000, result: 1.0, table: my-table
+_measurement: point, _start: 2022-10-13 07:56:08 +0000, _stop: 2022-10-13 07:57:08 +0000, _time: 2022-10-13 07:57:08 +0000, result: 2.0, table: my-table
+_measurement: point, _start: 2022-10-13 07:56:08 +0000, _stop: 2022-10-13 07:57:08 +0000, _time: 2022-10-13 07:57:08 +0000, result: 3.0, table: my-table
+_measurement: point, _start: 2022-10-13 07:56:08 +0000, _stop: 2022-10-13 07:57:08 +0000, _time: 2022-10-13 07:57:08 +0000, result: 4.0, table: my-table
+_measurement: point, _start: 2022-10-13 07:56:08 +0000, _stop: 2022-10-13 07:57:08 +0000, _time: 2022-10-13 07:57:08 +0000, result: 5.0, table: my-table
 -------------------------------------------- FluxRecord.row -------------------------------------------
-_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(1.0), my-table
-_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(2.0), my-table
-_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(3.0), my-table
-_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(4.0), my-table
-_result, Optional(0), Optional(2022-10-12 09:24:33 +0000), Optional(2022-10-12 09:25:33 +0000), Optional(2022-10-12 09:25:33 +0000), point, Optional(5.0), my-table
+_result, 0, 2022-10-13 07:56:08 +0000, 2022-10-13 07:57:08 +0000, 2022-10-13 07:57:08 +0000, point, 1.0, my-table
+_result, 0, 2022-10-13 07:56:08 +0000, 2022-10-13 07:57:08 +0000, 2022-10-13 07:57:08 +0000, point, 2.0, my-table
+_result, 0, 2022-10-13 07:56:08 +0000, 2022-10-13 07:57:08 +0000, 2022-10-13 07:57:08 +0000, point, 3.0, my-table
+_result, 0, 2022-10-13 07:56:08 +0000, 2022-10-13 07:57:08 +0000, 2022-10-13 07:57:08 +0000, point, 4.0, my-table
+_result, 0, 2022-10-13 07:56:08 +0000, 2022-10-13 07:57:08 +0000, 2022-10-13 07:57:08 +0000, point, 5.0, my-table
 
 ```

--- a/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
+++ b/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
@@ -1,0 +1,78 @@
+import ArgumentParser
+import Foundation
+import InfluxDBSwift
+import InfluxDBSwiftApis
+
+@main
+struct RecordRow: AsyncParsableCommand {
+    @Option(name: .shortAndLong, help: "The name or id of the bucket destination.")
+    private var bucket: String
+
+    @Option(name: .shortAndLong, help: "The name or id of the organization destination.")
+    private var org: String
+
+    @Option(name: .shortAndLong, help: "Authentication token.")
+    private var token: String
+
+    @Option(name: .shortAndLong, help: "HTTP address of InfluxDB.")
+    private var url: String
+}
+
+extension RecordRow {
+    mutating func run() async throws {
+        //
+        // Creating client
+        //
+        let client = InfluxDBClient(
+                url: url,
+                token: token,
+                options: InfluxDBClient.InfluxDBOptions(bucket: bucket, org: org))
+
+        //
+        // Write test data into InfluxDB
+        //
+        for i in 1...5 {
+            let point = InfluxDBClient
+                    .Point("point")
+                    .addField(key: "table", value: .string("my-table"))
+                    .addField(key: "result", value: .double(Double(i)))
+            try await client.makeWriteAPI().write(point: point)
+        }
+
+        //
+        // Query data with pivot
+        //
+        let query = """
+                    from(bucket: "\(self.bucket)")
+                    |> range(start: -1m) 
+                    |> filter(fn: (r) => (r["_measurement"] == "point"))
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+                    """
+        let records = try await client.queryAPI.query(query: query)
+
+        //
+        // Write data to output
+        //
+        var values: Array<String> = Array()
+        var row: Array<String> = Array()
+
+        try records.forEach { record in
+            values.append(record.values.sorted(by: { $0.0 < $1.0 }).map {
+                        val in
+                        "\(val.key): \(val.value)"
+                    }
+                    .joined(separator: ", "))
+            row.append(record.row.compactMap { val in
+                        "\(val)"
+                    }
+                    .joined(separator: ", "))
+        }
+
+        print("------------------------------------------ FluxRecord.values ------------------------------------------")
+        print(values.joined(separator: "\n"))
+        print("-------------------------------------------- FluxRecord.row -------------------------------------------")
+        print(row.joined(separator: "\n"))
+
+        client.close()
+    }
+}

--- a/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
+++ b/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
@@ -48,6 +48,7 @@ extension RecordRow {
                     |> filter(fn: (r) => (r["_measurement"] == "point"))
                     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
                     """
+
         let records = try await client.queryAPI.query(query: query)
 
         //

--- a/Sources/InfluxDBSwift/FluxCSVParser.swift
+++ b/Sources/InfluxDBSwift/FluxCSVParser.swift
@@ -143,40 +143,31 @@ internal class FluxCSVParser {
         }
         var recordRow: [Any] = Array()
         let values: [String: Decodable] = table.columns.reduce(into: [String: Decodable]()) { result, column in
-            let value: String = row[column.index + 1].isEmpty ? column.defaultValue : row[column.index + 1]
+            var value: String = row[column.index + 1]
+            if value.isEmpty {
+                value = column.defaultValue
+            }
             switch column.dataType {
             case "boolean":
-                let strVal = (value as NSString).boolValue
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = (value as NSString).boolValue
             case "unsignedLong":
-                let strVal = UInt64(value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = UInt64(value)
             case "long":
-                let strVal = Int64(value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = Int64(value)
             case "double":
-                let strVal = Double(value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = Double(value)
+            case "string":
+                result[column.name] = value
             case "dateTime:RFC3339", "dateTime:RFC3339Nano":
-                let strVal = CodableHelper.dateFormatter.date(from: value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = CodableHelper.dateFormatter.date(from: value)
             case "base64Binary":
-                let strVal = Data(base64Encoded: value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = Data(base64Encoded: value)
             case "duration":
-                let strVal = Int64(value)
-                result[column.name] = strVal
-                recordRow.append(strVal as Any)
+                result[column.name] = Int64(value)
             default:
                 result[column.name] = value
-                recordRow.append(value as Any)
             }
+            recordRow.append(result[column.name] ?? "" as Any)
         }
         return QueryAPI.FluxRecord(values: values, row: recordRow)
     }

--- a/Sources/InfluxDBSwift/FluxCSVParser.swift
+++ b/Sources/InfluxDBSwift/FluxCSVParser.swift
@@ -135,9 +135,9 @@ internal class FluxCSVParser {
                     $1.count > 1
                 }
                 .keys
-        if (duplicates.count > 0) {
+        if duplicates.count > 0 {
             print("""
-                  The response contains columns with duplicated names: \(duplicates.joined(separator: ", ")) 
+                  The response contains columns with duplicated names: \(duplicates.joined(separator: ", "))
                   You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values' dictionary.
                   """)
         }
@@ -147,7 +147,7 @@ internal class FluxCSVParser {
         guard let table = table else {
             throw InfluxDBClient.InfluxDBError.generic(Self.errorMessage)
         }
-        var recordRow: Array<Any> = Array()
+        var recordRow: [Any] = Array()
         let values: [String: Decodable] = table.columns.reduce(into: [String: Decodable]()) { result, column in
             var value: String = row[column.index + 1]
             if value.isEmpty {

--- a/Sources/InfluxDBSwift/QueryAPI.swift
+++ b/Sources/InfluxDBSwift/QueryAPI.swift
@@ -189,10 +189,10 @@ public class QueryAPI {
                          responseQueue: DispatchQueue = .main,
                          completion: @escaping (_ response: Data?, _ error: InfluxDBClient.InfluxDBError?) -> Void) {
         self.queryRaw(query: query,
-                org: org,
-                dialect: dialect,
-                params: params,
-                responseQueue: responseQueue) { result -> Void in
+                      org: org,
+                      dialect: dialect,
+                      params: params,
+                      responseQueue: responseQueue) { result -> Void in
             switch result {
             case let .success(data):
                 completion(data, nil)
@@ -252,10 +252,10 @@ public class QueryAPI {
                          responseQueue: DispatchQueue = .main) -> AnyPublisher<Data, InfluxDBClient.InfluxDBError> {
         Future<Data, InfluxDBClient.InfluxDBError> { promise in
             self.queryRaw(query: query,
-                    org: org,
-                    dialect: dialect,
-                    params: params,
-                    responseQueue: responseQueue) { result -> Void in
+                          org: org,
+                          dialect: dialect,
+                          params: params,
+                          responseQueue: responseQueue) { result -> Void in
                 switch result {
                 case let .success(data):
                     promise(.success(data))
@@ -344,7 +344,7 @@ extension QueryAPI {
             self.row = row
         }
 
-        public static func ==(lhs: FluxRecord, rhs: FluxRecord) -> Bool {
+        public static func == (lhs: FluxRecord, rhs: FluxRecord) -> Bool {
             NSDictionary(dictionary: lhs.values).isEqual(rhs.values)
         }
     }

--- a/Sources/InfluxDBSwift/QueryAPI.swift
+++ b/Sources/InfluxDBSwift/QueryAPI.swift
@@ -131,7 +131,7 @@ public class QueryAPI {
                       org: String? = nil,
                       params: [String: String]? = nil,
                       responseQueue: DispatchQueue = .main)
-                    -> AnyPublisher<FluxRecordCursor, InfluxDBClient.InfluxDBError> {
+            -> AnyPublisher<FluxRecordCursor, InfluxDBClient.InfluxDBError> {
         Future<FluxRecordCursor, InfluxDBClient.InfluxDBError> { promise in
             self.query(query: query, org: org, params: params, responseQueue: responseQueue) { result -> Void in
                 switch result {
@@ -141,7 +141,8 @@ public class QueryAPI {
                     promise(.failure(error))
                 }
             }
-        }.eraseToAnyPublisher()
+        }
+                .eraseToAnyPublisher()
     }
     #endif
 
@@ -188,10 +189,10 @@ public class QueryAPI {
                          responseQueue: DispatchQueue = .main,
                          completion: @escaping (_ response: Data?, _ error: InfluxDBClient.InfluxDBError?) -> Void) {
         self.queryRaw(query: query,
-                      org: org,
-                      dialect: dialect,
-                      params: params,
-                      responseQueue: responseQueue) { result -> Void in
+                org: org,
+                dialect: dialect,
+                params: params,
+                responseQueue: responseQueue) { result -> Void in
             switch result {
             case let .success(data):
                 completion(data, nil)
@@ -251,10 +252,10 @@ public class QueryAPI {
                          responseQueue: DispatchQueue = .main) -> AnyPublisher<Data, InfluxDBClient.InfluxDBError> {
         Future<Data, InfluxDBClient.InfluxDBError> { promise in
             self.queryRaw(query: query,
-                          org: org,
-                          dialect: dialect,
-                          params: params,
-                          responseQueue: responseQueue) { result -> Void in
+                    org: org,
+                    dialect: dialect,
+                    params: params,
+                    responseQueue: responseQueue) { result -> Void in
                 switch result {
                 case let .success(data):
                     promise(.success(data))
@@ -262,7 +263,8 @@ public class QueryAPI {
                     promise(.failure(error))
                 }
             }
-        }.eraseToAnyPublisher()
+        }
+                .eraseToAnyPublisher()
     }
     #endif
 
@@ -342,7 +344,7 @@ extension QueryAPI {
             self.row = row
         }
 
-        public static func == (lhs: FluxRecord, rhs: FluxRecord) -> Bool {
+        public static func ==(lhs: FluxRecord, rhs: FluxRecord) -> Bool {
             NSDictionary(dictionary: lhs.values).isEqual(rhs.values)
         }
     }

--- a/Sources/InfluxDBSwift/QueryAPI.swift
+++ b/Sources/InfluxDBSwift/QueryAPI.swift
@@ -330,11 +330,16 @@ extension QueryAPI {
         /// The list of values in Record
         public let values: [String: Decodable]
 
+        /// The array of record's columns
+        public let row: [Any]
+
         /// Initialize records with values.
         ///
         /// - Parameter values: record values
-        public init(values: [String: Decodable]) {
+        ///             row: record's columns
+        public init(values: [String: Decodable], row: [Any]) {
             self.values = values
+            self.row = row
         }
 
         public static func == (lhs: FluxRecord, rhs: FluxRecord) -> Bool {

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -488,7 +488,7 @@ final class FluxCSVParserTests: XCTestCase {
         XCTAssertEqual(3, records.count)
         XCTAssertEqual(7, records[0].values.count)
         XCTAssertEqual(8, records[0].row.count)
-        XCTAssertEqual(25.3, records[0].row[7])
+        XCTAssertEqual(25.3, records[0].row[7] as! Double)
     }
 
     // swiftlint:enable line_length trailing_whitespace

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -237,8 +237,9 @@ final class FluxCSVParserTests: XCTestCase {
 
         XCTAssertEqual(10, tuples[0].table.columns.count)
         XCTAssertEqual(2, tuples[0].table.columns.filter {
-            $0.group
-        }.count)
+                    $0.group
+                }
+                .count)
     }
 
     func testUnknownTypeAsString() throws {
@@ -471,6 +472,23 @@ final class FluxCSVParserTests: XCTestCase {
         XCTAssertEqual("0", records[0].values["table"] as? String)
         XCTAssertEqual("11", records[0].values["value1"] as? String)
         XCTAssertEqual("west", records[0].values["region"] as? String)
+    }
+
+    func testParseDuplicateColumnNames() throws {
+        let data = """
+                   #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+                    #group,false,false,true,true,false,true,true,false
+                    #default,_result,,,,,,,
+                     ,result,table,_start,_stop,_time,_measurement,location,result
+                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3
+                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3
+                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3
+                   """
+        let records = try parse_to_records(data: data, responseMode: .onlyNames)
+        XCTAssertEqual(3, records.count)
+        XCTAssertEqual(7, records[0].values.count)
+        XCTAssertEqual(8, records[0].row.count)
+        XCTAssertEqual(25.3, records[0].row[7])
     }
 
     // swiftlint:enable line_length trailing_whitespace

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -476,13 +476,14 @@ final class FluxCSVParserTests: XCTestCase {
 
     func testParseDuplicateColumnNames() throws {
         let data = """
-                   #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+                    #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
                     #group,false,false,true,true,false,true,true,false
                     #default,_result,,,,,,,
-                     ,result,table,_start,_stop,_time,_measurement,location,result
+                    ,result,table,_start,_stop,_time,_measurement,location,result
                     ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3
                     ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3
                     ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3
+
                    """
         let records = try parse_to_records(data: data, responseMode: .onlyNames)
         XCTAssertEqual(3, records.count)

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -238,7 +238,7 @@ final class FluxCSVParserTests: XCTestCase {
         XCTAssertEqual(10, tuples[0].table.columns.count)
         XCTAssertEqual(2, tuples[0].table.columns.filter {
                     $0.group
-                }
+        }
                 .count)
     }
 

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -476,20 +476,20 @@ final class FluxCSVParserTests: XCTestCase {
 
     func testParseDuplicateColumnNames() throws {
         let data = """
-                    #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
-                    #group,false,false,true,true,false,true,true,false
-                    #default,_result,,,,,,,
-                    ,result,table,_start,_stop,_time,_measurement,location,result
-                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3
-                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3
-                    ,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3
+                   #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,double,string
+                   #group,false,false,true,true,false,true,false,false
+                   #default,_result,,,,,,,
+                   ,result,table,_start,_stop,_time,_measurement,result,table
+                   ,,0,2022-10-12T08:36:55.358106426Z,2022-10-12T08:37:55.358106426Z,2022-10-12T08:37:55.316995385Z,point,25.3,my-table
+                   ,,0,2022-10-12T08:36:55.358106426Z,2022-10-12T08:37:55.358106426Z,2022-10-12T08:37:55.329323051Z,point,25.3,my-table
+                   ,,0,2022-10-12T08:36:55.358106426Z,2022-10-12T08:37:55.358106426Z,2022-10-12T08:37:55.336790801Z,point,25.3,my-table
 
                    """
-        let records = try parse_to_records(data: data, responseMode: .onlyNames)
+        let records = try parse_to_records(data: data, responseMode: .full)
         XCTAssertEqual(3, records.count)
-        XCTAssertEqual(7, records[0].values.count)
+        XCTAssertEqual(6, records[0].values.count)
         XCTAssertEqual(8, records[0].row.count)
-        XCTAssertEqual(25.3, records[0].row[7] as? Double)
+        XCTAssertEqual(25.3, records[0].row[6] as? Double)
     }
 
     // swiftlint:enable line_length trailing_whitespace

--- a/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
+++ b/Tests/InfluxDBSwiftTests/FluxCSVParserTests.swift
@@ -489,7 +489,7 @@ final class FluxCSVParserTests: XCTestCase {
         XCTAssertEqual(3, records.count)
         XCTAssertEqual(7, records[0].values.count)
         XCTAssertEqual(8, records[0].row.count)
-        XCTAssertEqual(25.3, records[0].row[7] as! Double)
+        XCTAssertEqual(25.3, records[0].row[7] as? Double)
     }
 
     // swiftlint:enable line_length trailing_whitespace


### PR DESCRIPTION
## Proposed Changes

Adding possibility of accessing response data in Array FluxRecord.row.

In case of using pivot on data, where field contains labels that occur by default in the annotated CSV (f.e. "result" or "table"), could be duplicated column names in response. In that case FluxRecord.values, which hold only unique keys, doesn't show complete data. This edge case is solved by using FluxRecord.row.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `swift test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
