### PR TITLE
feat: updated Point to be a sendable struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ Package.resolved
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## 1.8.0 [unreleased]
+## 2.0.0 [unreleased]
+
+`Point` has been updated from a class to a `Sendable` struct. This allows passing instances of `Point` across arbitrary concurrent contexts without introducing a risk of data races. Anywhere using `Point` will need to be updated to account for the change from a class to a struct.
+
+The minimum swift version has been raised to 5.7 to support the `Sendable` protocol.
+
+`addTag(key:value:)`, `addField(key:value:)`, and `time(time:)` have been deprecated in favor of passing values to `Point.init` or mutating the properties directly. Since the methods mutated the instance and returned the instance, they aren't compatible with `Point` becoming a struct. To simplify migration, each method now has two versions: one that mutates the instance and one that returns a new modified instance. The methods returning a new instance can still be chained together but the result must be assigned to a variable. The methods that mutate the instance can no longer be chained together, but don't require assigning the result to a variable.
+
+### Features
+1. [#69](https://github.com/influxdata/influxdb-client-swift/pull/69) Updated `Point` to be a sendable struct
+1. [#70](https://github.com/influxdata/influxdb-client-swift/pull/70): Improved usability of `Point` by adding tags, fields, and time to the initializer and making the properties public and mutable
 
 ## 1.7.0 [2024-05-17]
 

--- a/Examples/AsyncAwait/Sources/AsyncAwait/AsyncAwait.swift
+++ b/Examples/AsyncAwait/Sources/AsyncAwait/AsyncAwait.swift
@@ -35,10 +35,11 @@ extension AsyncAwait {
         //
         // Asynchronous write
         //
-        let point = InfluxDBClient
-                .Point("demo")
-                .addTag(key: "type", value: "point")
-                .addField(key: "value", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "demo",
+            tags: ["type": "point"],
+            fields: ["value": .int(2)]
+        )
         try await client.makeWriteAPI().write(point: point)
         print("Written data:\n > \(try point.toLineProtocol())")
 

--- a/Examples/InvokableScripts/Sources/InvokableScripts/InvokableScripts.swift
+++ b/Examples/InvokableScripts/Sources/InvokableScripts/InvokableScripts.swift
@@ -37,14 +37,16 @@ extension InvokableScriptsAPI {
         //
         // Prepare Data
         //
-        let point1 = InfluxDBClient
-                .Point("my_measurement")
-                .addTag(key: "location", value: "Prague")
-                .addField(key: "temperature", value: .double(25.3))
-        let point2 = InfluxDBClient
-                .Point("my_measurement")
-                .addTag(key: "location", value: "New York")
-                .addField(key: "temperature", value: .double(24.3))
+        let point1 = InfluxDBClient.Point(
+            "my_measurement",
+            tags: ["location": "Prague"],
+            fields: ["temperature": .double(25.3)]
+        )
+        let point2 = InfluxDBClient.Point(
+            "my_measurement",
+            tags: ["location": "New York"],
+            fields: ["temperature": .double(24.3)]
+        )
         try await client.makeWriteAPI().write(points: [point1, point2])
 
         //

--- a/Examples/ParameterizedQuery/Sources/ParameterizedQuery/ParameterizedQuery.swift
+++ b/Examples/ParameterizedQuery/Sources/ParameterizedQuery/ParameterizedQuery.swift
@@ -32,10 +32,11 @@ extension ParameterizedQuery {
                 options: InfluxDBClient.InfluxDBOptions(bucket: bucket, org: org))
 
         for index in 1...3 {
-            let point = InfluxDBClient
-                    .Point("demo")
-                    .addTag(key: "type", value: "point")
-                    .addField(key: "value", value: .int(index))
+            let point = InfluxDBClient.Point(
+                "demo",
+                tags: ["type": "point"],
+                fields: ["value": .int(index)]
+            )
             try await client.makeWriteAPI().write(point: point)
         }
 

--- a/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
+++ b/Examples/RecordRow/Sources/RecordRow/RecordRow.swift
@@ -32,10 +32,13 @@ extension RecordRow {
         // Write test data into InfluxDB
         //
         for i in 1...5 {
-            let point = InfluxDBClient
-                    .Point("point")
-                    .addField(key: "table", value: .string("my-table"))
-                    .addField(key: "result", value: .double(Double(i)))
+            let point = InfluxDBClient.Point(
+                "point",
+                fields: [
+                    "table": .string("my-table"),
+                    "result": .double(Double(i)),
+                ]
+            )
             try await client.makeWriteAPI().write(point: point)
         }
 

--- a/Examples/WriteData/Sources/WriteData/WriteData.swift
+++ b/Examples/WriteData/Sources/WriteData/WriteData.swift
@@ -35,18 +35,20 @@ extension WriteData {
         //
         // Record defined as Data Point
         //
-        let recordPoint = InfluxDBClient
-                .Point("demo")
-                .addTag(key: "type", value: "point")
-                .addField(key: "value", value: .int(2))
+        let recordPoint = InfluxDBClient.Point(
+            "demo",
+            tags: ["type": "point"],
+            fields: ["value": .int(2)]
+        )
         //
         // Record defined as Data Point with Timestamp
         //
-        let recordPointDate = InfluxDBClient
-                .Point("demo")
-                .addTag(key: "type", value: "point-timestamp")
-                .addField(key: "value", value: .int(2))
-                .time(time: .date(Date()))
+        let recordPointDate = InfluxDBClient.Point(
+            "demo",
+            tags: ["type": "point-timestamp"],
+            fields: ["value": .int(2)],
+            time: .date(Date())
+        )
 
         try await client.makeWriteAPI().write(points: [recordPoint, recordPointDate])
         print("Written data:\n\n\([recordPoint, recordPointDate].map { "\t- \($0)" }.joined(separator: "\n"))")

--- a/Examples/WriteDataInBatches/Sources/WriteDataInBatches/main.swift
+++ b/Examples/WriteDataInBatches/Sources/WriteDataInBatches/main.swift
@@ -86,14 +86,17 @@ struct WriteDataInBatches: ParsableCommand {
     ///   - dateFormatter: for parsing date
     /// - Returns: parsed InfluxDBClient.Point
     private func toPoint(row: [String], dateFormatter: DateFormatter) -> InfluxDBClient.Point {
-        InfluxDBClient
-                .Point("financial-analysis")
-                .addTag(key: "type", value: "vix-daily")
-                .addField(key: "open", value: .double(Double(row[1])!))
-                .addField(key: "high", value: .double(Double(row[2])!))
-                .addField(key: "low", value: .double(Double(row[3])!))
-                .addField(key: "close", value: .double(Double(row[4])!))
-                .time(time: .date(dateFormatter.date(from: row[0])!))
+        InfluxDBClient.Point(
+            "financial-analysis",
+            tags: ["type": "vix-daily"],
+            fields: [
+                "open": .double(Double(row[1])!),
+                "high": .double(Double(row[2])!),
+                "low": .double(Double(row[3])!),
+                "close": .double(Double(row[4])!)
+            ],
+            time: .date(dateFormatter.date(from: row[0])!)
+        )
     }
 
     private func atExit(client: InfluxDBClient, error: InfluxDBClient.InfluxDBError? = nil) {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,21 +11,27 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(name: "Gzip", url: "https://github.com/1024jp/GzipSwift", from: "5.1.1"),
-         .package(name: "CSV.swift", url: "https://github.com/yaslab/CSV.swift", from: "2.4.2"),
-         .package(name: "SwiftTestReporter", url: "https://github.com/allegro/swift-junit.git", from: "2.0.0"),
-         .package(name: "swift-log", url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+         .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.1"),
+         .package(url: "https://github.com/yaslab/CSV.swift", from: "2.4.2"),
+         .package(url: "https://github.com/allegro/swift-junit.git", from: "2.0.0"),
+         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(name: "InfluxDBSwift", dependencies: [
-            "Gzip",
+            .product(name: "Gzip", package: "GzipSwift"),
             .product(name: "CSV", package: "CSV.swift"),
             .product(name: "Logging", package: "swift-log")
         ]),
         .target(name: "InfluxDBSwiftApis", dependencies: ["InfluxDBSwift"]),
-        .testTarget(name: "InfluxDBSwiftTests", dependencies: ["InfluxDBSwift", "SwiftTestReporter"]),
-        .testTarget(name: "InfluxDBSwiftApisTests", dependencies: ["InfluxDBSwiftApis", "SwiftTestReporter"]),
+        .testTarget(name: "InfluxDBSwiftTests", dependencies: [
+            "InfluxDBSwift",
+                .product(name: "SwiftTestReporter", package: "swift-junit")
+        ]),
+        .testTarget(name: "InfluxDBSwiftApisTests", dependencies: [
+            "InfluxDBSwiftApis",
+            .product(name: "SwiftTestReporter", package: "swift-junit")
+        ]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ InfluxDB 2.x client consists of two packages
 
 ## Supported Platforms
 
-This package requires Swift 5 and Xcode 12+.
+This package requires Swift 5.7 and Xcode 14+.
 
 - iOS 14.0+
 - macOS 11.0+
@@ -70,24 +70,24 @@ This package requires Swift 5 and Xcode 12+.
 
 Add this line to your `Package.swift` :
 
-~~~swift
-// swift-tools-version:5.3
+```swift
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "1.7.0"),
+        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "2.0.0"),
     ],
     targets: [
         .target(name: "MyModule", dependencies: [
-          .product(name: "InfluxDBSwift", package: "influxdb-client-swift"),
-          // or InfluxDBSwiftApis for management API
-          .product(name: "InfluxDBSwiftApis", package: "influxdb-client-swift")
+            .product(name: "InfluxDBSwift", package: "influxdb-client-swift"),
+            // or InfluxDBSwiftApis for management API
+            .product(name: "InfluxDBSwiftApis", package: "influxdb-client-swift")
         ])
     ]
 )
-~~~
+```
 
 ## Usage
 
@@ -187,25 +187,27 @@ extension WriteData {
     // Initialize Client with default Bucket and Organization
     //
     let client = InfluxDBClient(
-            url: url,
-            token: token,
-            options: InfluxDBClient.InfluxDBOptions(bucket: bucket, org: org))
-
+      url: url,
+      token: token,
+      options: InfluxDBClient.InfluxDBOptions(bucket: bucket, org: org)
+    )
     //
     // Record defined as Data Point
     //
-    let recordPoint = InfluxDBClient
-            .Point("demo")
-            .addTag(key: "type", value: "point")
-            .addField(key: "value", value: .int(2))
+    let recordPoint = InfluxDBClient.Point(
+        "demo",
+        tags: ["type": "point"],
+        fields: ["value": .int(2)]
+    )
     //
     // Record defined as Data Point with Timestamp
     //
-    let recordPointDate = InfluxDBClient
-            .Point("demo")
-            .addTag(key: "type", value: "point-timestamp")
-            .addField(key: "value", value: .int(2))
-            .time(time: .date(Date()))
+    let recordPointDate = InfluxDBClient.Point(
+      "demo",
+      tags: ["type": "point-timestamp"],
+      fields: ["value": .int(2)],
+      time: .date(Date())
+    )
 
     try await client.makeWriteAPI().write(points: [recordPoint, recordPointDate])
     print("Written data:\n\n\([recordPoint, recordPointDate].map { "\t- \($0)" }.joined(separator: "\n"))")
@@ -375,10 +377,11 @@ extension ParameterizedQuery {
             options: InfluxDBClient.InfluxDBOptions(bucket: bucket, org: org))
 
     for index in 1...3 {
-      let point = InfluxDBClient
-              .Point("demo")
-              .addTag(key: "type", value: "point")
-              .addField(key: "value", value: .int(index))
+      let point = InfluxDBClient.Point(
+        "demo",
+        tags: ["type": "point"],
+        fields: ["value", value: .int(index)]
+      )
       try await client.makeWriteAPI().write(point: point)
     }
 
@@ -602,9 +605,11 @@ let tuple: InfluxDBClient.Point.Tuple
         = (measurement: "mem", tags: ["tag": "a"], fields: ["value": .int(3)], time: nil)
 
 let records: [Any] = [
-        InfluxDBClient.Point("mining")
-                .addTag(key: "sensor_state", value: "normal")
-                .addField(key: "depth", value: .int(2)),
+        InfluxDBClient.Point(
+          "mining",
+          tags: ["sensor_state": "normal"],
+                fields: ["depth": .int(2)]
+        ),
         tuple
 ]
 

--- a/Sources/InfluxDBSwift/InfluxDBClient.swift
+++ b/Sources/InfluxDBSwift/InfluxDBClient.swift
@@ -24,7 +24,7 @@ import FoundationNetworking
 /// ````
 public struct InfluxDBClient {
     /// Version of client.
-    public static var version: String = "1.8.0dev"
+    public static var version: String = "2.0.0dev"
     /// InfluxDB host and port.
     public let url: String
     /// Authentication token.
@@ -247,7 +247,7 @@ extension InfluxDBClient {
 
     /// An enum represents the precision for the unix timestamps within the body line-protocol.
     /// - SeeAlso: https://docs.influxdata.com/influxdb/latest/write-data/#timestamp-precision
-    public enum TimestampPrecision: String, Codable, CaseIterable {
+    public enum TimestampPrecision: String, Codable, CaseIterable, Sendable {
         /// Milliseconds
         case ms
         /// Seconds

--- a/Sources/InfluxDBSwift/Point.swift
+++ b/Sources/InfluxDBSwift/Point.swift
@@ -8,62 +8,31 @@ extension InfluxDBClient {
     /// Point defines the values that will be written to the database.
     ///
     /// - SeeAlso: http://bit.ly/influxdata-point
-    public class Point {
+    public struct Point: Sendable {
         /// The measurement name.
-        private let measurement: String
+        public let measurement: String
         // The measurement tags.
-        private var tags: [String: String?] = [:]
+        public var tags: [String: String]
         // The measurement fields.
-        private var fields: [String: FieldValue?] = [:]
+        public var fields: [String: FieldValue]
         /// The data point time.
-        var time: TimestampValue?
+        public var time: TimestampValue?
 
         /// Create a new Point with specified a measurement name and precision.
         ///
         /// - Parameters:
         ///   - measurement: the measurement name
         ///   - precision: the data point precision
-        public init(_ measurement: String) {
+        public init(
+            _ measurement: String,
+            tags: [String: String] = [:],
+            fields: [String: FieldValue] = [:],
+            time: TimestampValue? = nil
+        ) {
             self.measurement = measurement
-        }
-
-        /// Adds or replaces a tag value for this point.
-        ///
-        /// - Parameters:
-        ///   - key: the tag name
-        ///   - value: the tag value
-        /// - Returns: self
-        @discardableResult
-        public func addTag(key: String?, value: String?) -> Point {
-            if let key = key {
-                tags[key] = value
-            }
-            return self
-        }
-
-        /// Adds or replaces a field value for this point.
-        ///
-        /// - Parameters:
-        ///   - key: the field name
-        ///   - value: the field value
-        /// - Returns: self
-        @discardableResult
-        public func addField(key: String?, value: FieldValue?) -> Point {
-            if let key = key {
-                fields[key] = value
-            }
-            return self
-        }
-
-        /// Updates the timestamp for the point.
-        ///
-        /// - Parameters:
-        ///   - time: the timestamp. It can be `Int` or `Date`.
-        /// - Returns: self
-        @discardableResult
-        public func time(time: TimestampValue) -> Point {
+            self.tags = tags
+            self.fields = fields
             self.time = time
-            return self
         }
 
         /// Creates Line Protocol from Data Point.
@@ -73,7 +42,7 @@ extension InfluxDBClient {
         ///   - defaultTags: default tags for Point.
         /// - Returns: Line Protocol
         public func toLineProtocol(precision: TimestampPrecision = defaultTimestampPrecision,
-                                   defaultTags: [String: String?]? = nil) throws -> String? {
+                                   defaultTags: [String: String]? = nil) throws -> String? {
             let meas = escapeKey(measurement, false)
             let tags = escapeTags(defaultTags)
             let fields = try escapeFields()
@@ -117,8 +86,8 @@ extension InfluxDBClient {
             return self
         }
 
-        internal func evaluate() -> [String: String?] {
-            let map: [String: String?] = tags.mapValues { value in
+        internal func evaluate() -> [String: String] {
+            let map: [String: String] = tags.compactMapValues { value in
                 if let value = value, value.starts(with: "${env.") {
                     let start = value.index(value.startIndex, offsetBy: 6)
                     let end = value.index(value.endIndex, offsetBy: -1)
@@ -134,7 +103,7 @@ extension InfluxDBClient {
 
 extension InfluxDBClient.Point {
     /// Possible value types of Field
-    public enum FieldValue {
+    public enum FieldValue: Sendable {
         /// Support for Int8
         init(_ value: Int8) {
             self = .int(Int(value))
@@ -185,7 +154,7 @@ extension InfluxDBClient.Point {
     }
 
     /// Possible value types of Field
-    public enum TimestampValue: CustomStringConvertible {
+    public enum TimestampValue: CustomStringConvertible, Sendable {
         // The number of ticks since the UNIX epoch. The value has to be specified with correct precision.
         case interval(Int, InfluxDBClient.TimestampPrecision = InfluxDBClient.defaultTimestampPrecision)
         // The date timestamp.
@@ -205,8 +174,8 @@ extension InfluxDBClient.Point {
 extension InfluxDBClient.Point {
     /// Tuple definition for construct `Point`.
     public typealias Tuple = (measurement: String,
-                              tags: [String?: String?]?,
-                              fields: [String?: InfluxDBClient.Point.FieldValue?],
+                              tags: [String: String]?,
+                              fields: [String: InfluxDBClient.Point.FieldValue],
                               time: InfluxDBClient.Point.TimestampValue?)
     /// Create a new Point from Tuple.
     ///
@@ -214,20 +183,13 @@ extension InfluxDBClient.Point {
     ///   - tuple: the tuple with keys: `measurement`, `tags`, `fields` and `time`
     ///   - precision: the data point precision
     /// - Returns: created Point
-    public class func fromTuple(_ tuple: Tuple) -> InfluxDBClient.Point {
-        let point = InfluxDBClient.Point(tuple.measurement)
-        if let tags = tuple.tags {
-            for tag in tags {
-                point.addTag(key: tag.0, value: tag.1)
-            }
-        }
-        for field in tuple.fields {
-            point.addField(key: field.0, value: field.1)
-        }
-        if let time = tuple.time {
-            point.time(time: time)
-        }
-        return point
+    public static func fromTuple(_ tuple: Tuple) -> InfluxDBClient.Point {
+        .init(
+            tuple.measurement,
+            tags: tuple.tags ?? [:],
+            fields: tuple.fields,
+            time: tuple.time
+        )
     }
 }
 
@@ -261,7 +223,7 @@ extension InfluxDBClient.Point {
         }
     }
 
-    private func escapeTags(_ defaultTags: [String: String?]?) -> String {
+    private func escapeTags(_ defaultTags: [String: String]?) -> String {
         tags
                 .merging(defaultTags ?? [:]) { current, _ in
                     current
@@ -272,11 +234,11 @@ extension InfluxDBClient.Point {
                     guard !keyValue.key.isEmpty else {
                         return
                     }
-                    if let value = keyValue.value, !value.isEmpty {
+                    if !keyValue.value.isEmpty {
                         result.append(",")
                         result.append(escapeKey(keyValue.key))
                         result.append("=")
-                        result.append(escapeKey(value))
+                        result.append(escapeKey(keyValue.value))
                     }
                 }
     }
@@ -288,10 +250,7 @@ extension InfluxDBClient.Point {
             if keyValue.key.isEmpty {
                 return
             }
-            guard let value = keyValue.value else {
-                return
-            }
-            if let escaped = try escapeValue(value) {
+            if let escaped = try escapeValue(keyValue.value) {
                 // key
                 result.append(escapeKey(keyValue.key))
                 // key=
@@ -384,5 +343,88 @@ extension InfluxDBClient.Point {
         }
 
         return " \(sinceEpoch)"
+    }
+}
+
+extension InfluxDBClient.Point {
+    /// Adds or replaces a tag value for this point.
+    ///
+    /// - Parameters:
+    ///   - key: the tag name
+    ///   - value: the tag value
+    /// - Returns: self
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Pass tags to Point.init or use the tags property")
+    public func addTag(key: String?, value: String?) -> Self {
+        var point = self
+        if let key = key {
+            point.tags[key] = value
+        }
+        return point
+    }
+
+    /// Adds or replaces a tag value for this point.
+    ///
+    /// - Parameters:
+    ///   - key: the tag name
+    ///   - value: the tag value
+    /// - Returns: self
+    @available(*, deprecated, message: "Pass tags to Point.init or use the tags property")
+    public mutating func addTag(key: String?, value: String?) {
+        if let key = key {
+            tags[key] = value
+        }
+    }
+
+    /// Adds or replaces a field value for this point.
+    ///
+    /// - Parameters:
+    ///   - key: the field name
+    ///   - value: the field value
+    /// - Returns: self
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Pass fields to Point.init or use the fields property")
+    public func addField(key: String?, value: FieldValue?) -> Self {
+        var point = self
+        if let key = key {
+            point.fields[key] = value
+        }
+        return point
+    }
+
+    /// Adds or replaces a field value for this point.
+    ///
+    /// - Parameters:
+    ///   - key: the field name
+    ///   - value: the field value
+    /// - Returns: self
+    @available(*, deprecated, message: "Pass fields to Point.init or use the fields property")
+    public mutating func addField(key: String?, value: FieldValue?) {
+        if let key = key {
+            fields[key] = value
+        }
+    }
+
+    /// Updates the timestamp for the point.
+    ///
+    /// - Parameters:
+    ///   - time: the timestamp. It can be `Int` or `Date`.
+    /// - Returns: self
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Pass time to Point.init or use the time property")
+    public func time(time: TimestampValue) -> Self {
+        var point = self
+        point.time = time
+        return point
+    }
+
+    /// Updates the timestamp for the point.
+    ///
+    /// - Parameters:
+    ///   - time: the timestamp. It can be `Int` or `Date`.
+    /// - Returns: self
+    @available(*, deprecated, message: "Pass time to Point.init or use the time property")
+    public mutating func time(time: TimestampValue) {
+        self.time = time
     }
 }

--- a/Sources/InfluxDBSwift/WriteAPI.swift
+++ b/Sources/InfluxDBSwift/WriteAPI.swift
@@ -801,7 +801,7 @@ public struct WriteAPI {
 
     private func toLineProtocol(precision: InfluxDBClient.TimestampPrecision,
                                 any: Any,
-                                defaultTags: [String: String?]?,
+                                defaultTags: [String: String]?,
                                 lps: inout [String]) throws {
         // To avoid: "Could not cast value of type 'InfluxDBSwift.InfluxDBClient.Point' to 'Foundation.NSObject'."
         // on Linux - see:
@@ -831,7 +831,7 @@ public struct WriteAPI {
 
     private func toLineProtocol(precision: InfluxDBClient.TimestampPrecision,
                                 point: InfluxDBClient.Point,
-                                defaultTags: [String: String?]?,
+                                defaultTags: [String: String]?,
                                 lps: inout [String]) throws {
         if let lineProtocol = try point.toLineProtocol(precision: precision, defaultTags: defaultTags) {
             return toLineProtocol(

--- a/Tests/InfluxDBSwiftTests/IntegrationTests.swift
+++ b/Tests/InfluxDBSwiftTests/IntegrationTests.swift
@@ -38,11 +38,15 @@ final class IntegrationTests: XCTestCase {
         let measurement = "h2o_\(Date().timeIntervalSince1970)"
 
         let points = Array(1...5).map {
-            InfluxDBClient.Point(measurement)
-                    .addTag(key: "host", value: "aws")
-                    .addTag(key: "location", value: "west")
-                    .addField(key: "value", value: .int($0))
-                    .time(time: .date(Date(2020, 7, $0)))
+            InfluxDBClient.Point(
+                measurement,
+                tags: [
+                    "host": "aws",
+                    "location": "west"
+                ],
+                fields: ["value": .int($0)],
+                time: .date(Date(2020, 7, $0))
+            )
         }
 
         client.makeWriteAPI().write(points: points) { _, error in
@@ -92,23 +96,35 @@ final class IntegrationTests: XCTestCase {
 
         let measurement = "h2o_\(Date().timeIntervalSince1970)"
 
-        let point1 = InfluxDBClient.Point(measurement)
-                .addTag(key: "host", value: "aws")
-                .addTag(key: "location", value: "west")
-                .addField(key: "value", value: .int(1))
-                .time(time: .date(Date(2020, 7, 1)))
+        let point1 = InfluxDBClient.Point(
+            measurement,
+            tags: [
+                "host": "aws",
+                "location": "west"
+            ],
+            fields: ["value": .int(1)],
+            time: .date(Date(2020, 7, 1))
+        )
 
-        let point2 = InfluxDBClient.Point(measurement)
-                .addTag(key: "host", value: "azure")
-                .addTag(key: "location", value: "west")
-                .addField(key: "value", value: .int(2))
-                .time(time: .date(Date(2020, 7, 2)))
+        let point2 = InfluxDBClient.Point(
+            measurement,
+            tags: [
+                "host": "azure",
+                "location": "west"
+            ],
+            fields: ["value": .int(2)],
+            time: .date(Date(2020, 7, 2))
+        )
 
-        let point3 = InfluxDBClient.Point(measurement)
-                .addTag(key: "host", value: "gc")
-                .addTag(key: "location", value: "west")
-                .addField(key: "value", value: .int(3))
-                .time(time: .date(Date(2020, 7, 3)))
+        let point3 = InfluxDBClient.Point(
+            measurement,
+            tags: [
+                "host": "gc",
+                "location": "west"
+            ],
+            fields: ["value": .int(3)],
+            time: .date(Date(2020, 7, 3))
+        )
 
         client.makeWriteAPI().write(points: [point1, point2, point3]) { _, error in
             if let error = error {

--- a/Tests/InfluxDBSwiftTests/PointSettingsTests.swift
+++ b/Tests/InfluxDBSwiftTests/PointSettingsTests.swift
@@ -39,8 +39,7 @@ final class PointSettingsTests: XCTestCase {
                 .addDefaultTag(key: "not_exist", value: "${env.NOT_EXIST_KEY}")
 
         XCTAssertEqual([
-            "id": "132-987-655",
-            "not_exist": nil
+            "id": "132-987-655"
         ], defaultTags.evaluate())
     }
 
@@ -50,8 +49,7 @@ final class PointSettingsTests: XCTestCase {
                 .addDefaultTag(key: "nil", value: nil)
 
         XCTAssertEqual([
-            "id": "132-987-655",
-            "nil": nil
+            "id": "132-987-655"
         ], defaultTags.evaluate())
     }
 }

--- a/Tests/InfluxDBSwiftTests/PointTests.swift
+++ b/Tests/InfluxDBSwiftTests/PointTests.swift
@@ -9,44 +9,65 @@ import XCTest
 
 final class PointTests: XCTestCase {
     func testMeasurementEscape() {
-        var point = InfluxDBClient.Point("h2 o")
-                .addTag(key: "location", value: "europe")
-                .addTag(key: "", value: "warm")
-                .addField(key: "level", value: .int(2))
+        var point = InfluxDBClient.Point(
+            "h2 o",
+            tags: [
+                "location": "europe",
+                "": "warm"
+            ],
+            fields: ["level": .int(2)]
+        )
+
         XCTAssertEqual("h2\\ o,location=europe level=2i", try point.toLineProtocol())
 
-        point = InfluxDBClient.Point("h2,o")
-                .addTag(key: "location", value: "europe")
-                .addTag(key: "", value: "warn")
-                .addField(key: "level", value: .int(2))
+        point = InfluxDBClient.Point(
+            "h2,o",
+            tags: [
+                "location": "europe",
+                "": "warn"
+            ],
+            fields: ["level": .int(2)]
+        )
 
         XCTAssertEqual("h2\\,o,location=europe level=2i", try point.toLineProtocol())
     }
 
     func testTagEmptyKey() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addTag(key: "", value: "warn")
-                .addField(key: "level", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: [
+                "location": "europe",
+                "": "warn"
+            ],
+            fields: ["level": .int(2)]
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i", try point.toLineProtocol())
     }
 
     func testTagEmptyValue() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addTag(key: "log", value: "")
-                .addField(key: "level", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: [
+                "location": "europe",
+                "log": ""
+            ],
+            fields: ["level": .int(2)]
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i", try point.toLineProtocol())
     }
 
     func testTagEscapingKeyAndValue() {
-        let point = InfluxDBClient.Point("h\n2\ro\t_data")
-                .addTag(key: "new\nline", value: "new\nline")
-                .addTag(key: "carriage\rreturn", value: "carriage\nreturn")
-                .addTag(key: "t\tab", value: "t\tab")
-                .addField(key: "level", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "h\n2\ro\t_data",
+            tags: [
+                "new\nline": "new\nline",
+                "carriage\rreturn": "carriage\nreturn",
+                "t\tab": "t\tab"
+            ],
+            fields: ["level": .int(2)]
+        )
 
         XCTAssertEqual(
                 "h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i",
@@ -54,31 +75,39 @@ final class PointTests: XCTestCase {
     }
 
     func testEqualSignEscaping() {
-        let point = InfluxDBClient.Point("h=2o")
-                .addTag(key: "l=ocation", value: "e=urope")
-                .addField(key: "l=evel", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "h=2o",
+            tags: ["l=ocation": "e=urope"],
+            fields: ["l=evel": .int(2)]
+        )
 
         XCTAssertEqual("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", try point.toLineProtocol())
     }
 
     func testOverrideTagField() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addTag(key: "location", value: "europe2")
-                .addField(key: "level", value: .int(2))
-                .addField(key: "level", value: .int(3))
+        var point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .int(1)]
+        )
+
+        point.tags["location"] = "europe2"
+        point.fields["level"] = .int(3)
 
         XCTAssertEqual("h2o,location=europe2 level=3i", try point.toLineProtocol())
     }
 
     func testFieldTypes() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "decimal", value: .int(123))
-                .addField(key: "float", value: .double(250.69))
-                .addField(key: "bool", value: .boolean(false))
-                .addField(key: "string", value: .string("string value"))
-
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: [
+                "decimal": .int(123),
+                "float": .double(250.69),
+                "bool": .boolean(false),
+                "string": .string("string value")
+            ]
+        )
         let expected = "h2o,location=europe bool=false,decimal=123i,float=250.69,string=\"string value\""
 
         XCTAssertEqual(expected, try point.toLineProtocol())
@@ -91,12 +120,16 @@ final class PointTests: XCTestCase {
         let dNumber: Int32 = 12
         let eNumber: Int64 = 15
 
-        let point = InfluxDBClient.Point("h2o")
-                .addField(key: "a", value: .int(aNumber))
-                .addField(key: "b", value: InfluxDBClient.Point.FieldValue(bNumber))
-                .addField(key: "c", value: InfluxDBClient.Point.FieldValue(cNumber))
-                .addField(key: "d", value: InfluxDBClient.Point.FieldValue(dNumber))
-                .addField(key: "e", value: InfluxDBClient.Point.FieldValue(eNumber))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            fields: [
+                "a": .int(aNumber),
+                "b": InfluxDBClient.Point.FieldValue(bNumber),
+                "c": InfluxDBClient.Point.FieldValue(cNumber),
+                "d": InfluxDBClient.Point.FieldValue(dNumber),
+                "e": InfluxDBClient.Point.FieldValue(eNumber)
+            ]
+        )
 
         XCTAssertEqual("h2o a=3i,b=6i,c=9i,d=12i,e=15i", try point.toLineProtocol())
     }
@@ -108,44 +141,45 @@ final class PointTests: XCTestCase {
         let dNumber: UInt32 = 12
         let eNumber: UInt64 = 15
 
-        let point = InfluxDBClient.Point("h2o")
-                .addField(key: "a", value: .uint(aNumber))
-                .addField(key: "b", value: InfluxDBClient.Point.FieldValue(bNumber))
-                .addField(key: "c", value: InfluxDBClient.Point.FieldValue(cNumber))
-                .addField(key: "d", value: InfluxDBClient.Point.FieldValue(dNumber))
-                .addField(key: "e", value: InfluxDBClient.Point.FieldValue(eNumber))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            fields: [
+                "a": .uint(aNumber),
+                "b": InfluxDBClient.Point.FieldValue(bNumber),
+                "c": InfluxDBClient.Point.FieldValue(cNumber),
+                "d": InfluxDBClient.Point.FieldValue(dNumber),
+                "e": InfluxDBClient.Point.FieldValue(eNumber)
+            ]
+        )
 
         XCTAssertEqual("h2o a=3u,b=6u,c=9u,d=12u,e=15u", try point.toLineProtocol())
     }
 
-    func testFieldNullValue() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .int(2))
-                .addField(key: "warning", value: nil)
-
-        XCTAssertEqual("h2o,location=europe level=2i", try point.toLineProtocol())
-    }
-
     func testFieldEscape() {
-        var point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .string("string esc\\ape value"))
+        var point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .string("string esc\\ape value")]
+        )
 
         XCTAssertEqual("h2o,location=europe level=\"string esc\\\\ape value\"", try point.toLineProtocol())
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .string("string esc\"ape value"))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .string("string esc\"ape value")]
+        )
 
         XCTAssertEqual("h2o,location=europe level=\"string esc\\\"ape value\"", try point.toLineProtocol())
     }
 
     func testTime() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .int(2))
-                .time(time: .interval(123, .s))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .int(2)],
+            time: .interval(123, .s)
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i 123000000000", try point.toLineProtocol())
     }
@@ -153,56 +187,70 @@ final class PointTests: XCTestCase {
     func testDateTimeFormatting() {
         var date = Date(2015, 10, 15, 8, 20, 15)
 
-        var point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .int(2))
-                .time(time: .date(date))
+        var point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .int(2)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i 1444897215000", try point.toLineProtocol(precision: .ms))
 
         date = Date(2015, 10, 15, 8, 20, 15, 0, TimeZone(abbreviation: "JST"))
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .int(2))
-                .time(time: .date(date))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .int(2)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i 1444864815000", try point.toLineProtocol(precision: .ms))
 
         date = Date(2015, 10, 15, 8, 20, 15, 750)
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .boolean(false))
-                .time(time: .date(date))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .boolean(false)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=false 1444897215", try point.toLineProtocol(precision: .s))
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .boolean(false))
-                .time(time: .date(date))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .boolean(false)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=false 1444897215000", try point.toLineProtocol(precision: .ms))
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .boolean(false))
-                .time(time: .date(date))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .boolean(false)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=false 1444897215000750", try point.toLineProtocol(precision: .us))
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .boolean(false))
-                .time(time: .date(date))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .boolean(false)],
+            time: .date(date)
+        )
 
         XCTAssertEqual("h2o,location=europe level=false 1444897215000750080", try point.toLineProtocol(precision: .ns))
 
-        point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "level", value: .boolean(true))
-                .time(time: .date(Date()))
+        point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: ["level": .boolean(true)],
+            time: .date(Date())
+        )
 
         XCTAssertFalse(try point.toLineProtocol(precision: .s)!.contains("."))
     }
@@ -210,22 +258,32 @@ final class PointTests: XCTestCase {
     func testPointProtocol() {
         let date = Date(2009, 11, 10, 23, 0, 0)
 
-        var point = InfluxDBClient.Point("weather")
-                .time(time: .date(date))
-                .addTag(key: "location", value: "Přerov")
-                .addTag(key: "sid", value: "12345")
-                .addField(key: "temperature", value: .double(30.1))
-                .addField(key: "int_field", value: .int(2))
-                .addField(key: "float_field", value: .int(0))
+        var point = InfluxDBClient.Point(
+            "weather",
+            tags: [
+                "location": "Přerov",
+                "sid": "12345"
+            ],
+            fields: [
+                "temperature": .double(30.1),
+                "int_field": .int(2),
+                "float_field": .int(0)
+            ],
+            time: .date(date)
+        )
 
         XCTAssertEqual(
-                "weather,location=Přerov,sid=12345 float_field=0i,int_field=2i,temperature=30.1 1257894000000",
-                try point.toLineProtocol(precision: .ms))
+            "weather,location=Přerov,sid=12345 float_field=0i,int_field=2i,temperature=30.1 1257894000000",
+            try point.toLineProtocol(precision: .ms))
 
-        point = InfluxDBClient.Point("weather")
-                .time(time: .date(date))
-                .addField(key: "temperature", value: .double(30.1))
-                .addField(key: "float_field", value: .int(0))
+        point = InfluxDBClient.Point(
+            "weather",
+            fields: [
+                "temperature": .double(30.1),
+                "float_field": .int(0)
+            ],
+            time: .date(date)
+        )
 
         XCTAssertEqual(
                 "weather float_field=0i,temperature=30.1 1257894000000",
@@ -239,38 +297,52 @@ final class PointTests: XCTestCase {
         let expUTC = "A val=1i 1257894000000000000"
         let expBerlin = "A val=1i 1257890400000000000"
 
-        let point = InfluxDBClient.Point("A")
-                .addField(key: "val", value: .int(1))
-                .time(time: .date(utc))
+        var point = InfluxDBClient.Point(
+            "A",
+            fields: ["val": .int(1)],
+            time: .date(utc)
+        )
 
         XCTAssertEqual(expUTC, try point.toLineProtocol())
-        XCTAssertEqual(expUTC, try point.time(time: .date(utc)).toLineProtocol())
-        XCTAssertEqual(expBerlin, try point.time(time: .date(berlin)).toLineProtocol())
+
+        point.time = .date(utc)
+        XCTAssertEqual(expUTC, try point.toLineProtocol())
+
+        point.time = .date(berlin)
+        XCTAssertEqual(expBerlin, try point.toLineProtocol())
     }
 
     func testInfinityValues() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "decimal-infinity-positive", value: .double(Double.infinity))
-                .addField(key: "decimal-infinity-negative", value: .double(-Double.infinity))
-                .addField(key: "decimal-nan", value: .double(-Double.nan))
-                .addField(key: "float-infinity-positive", value: InfluxDBClient.Point.FieldValue(Float.infinity))
-                .addField(key: "float-infinity-negative", value: InfluxDBClient.Point.FieldValue(-Float.infinity))
-                .addField(key: "float-nan", value: InfluxDBClient.Point.FieldValue(Float.nan))
-                .addField(key: "level", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: [
+                "decimal-infinity-positive": .double(Double.infinity),
+                "decimal-infinity-negative": .double(-Double.infinity),
+                "decimal-nan": .double(-Double.nan),
+                "float-infinity-positive": InfluxDBClient.Point.FieldValue(Float.infinity),
+                "float-infinity-negative": InfluxDBClient.Point.FieldValue(-Float.infinity),
+                "float-nan": InfluxDBClient.Point.FieldValue(Float.nan),
+                "level": .int(2)
+            ]
+        )
 
         XCTAssertEqual("h2o,location=europe level=2i", try point.toLineProtocol())
     }
 
     func testOnlyInfinityValues() {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "location", value: "europe")
-                .addField(key: "decimal-infinity-positive", value: .double(Double.infinity))
-                .addField(key: "decimal-infinity-negative", value: .double(-Double.infinity))
-                .addField(key: "decimal-nan", value: .double(-Double.nan))
-                .addField(key: "float-infinity-positive", value: InfluxDBClient.Point.FieldValue(Float.infinity))
-                .addField(key: "float-infinity-negative", value: InfluxDBClient.Point.FieldValue(-Float.infinity))
-                .addField(key: "float-nan", value: InfluxDBClient.Point.FieldValue(Float.nan))
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["location": "europe"],
+            fields: [
+                "decimal-infinity-positive": .double(Double.infinity),
+                "decimal-infinity-negative": .double(-Double.infinity),
+                "decimal-nan": .double(-Double.nan),
+                "float-infinity-positive": InfluxDBClient.Point.FieldValue(Float.infinity),
+                "float-infinity-negative": InfluxDBClient.Point.FieldValue(-Float.infinity),
+                "float-nan": InfluxDBClient.Point.FieldValue(Float.nan)
+            ]
+        )
 
         XCTAssertNil(try point.toLineProtocol())
     }
@@ -279,14 +351,17 @@ final class PointTests: XCTestCase {
         let utc = Date(2020, 7, 4, 0, 0, 0, 123456)
         let hongKong = Date(2020, 7, 4, 8, 0, 0, 123456, TimeZone(identifier: "Asia/Hong_Kong"))  // +08:00
 
-        let pointUTC = try InfluxDBClient.Point("h2o")
-                .addField(key: "val", value: .int(1))
-                .time(time: .date(utc))
-                .toLineProtocol()
-        let pointHK = try InfluxDBClient.Point("h2o")
-                .addField(key: "val", value: .int(1))
-                .time(time: .date(hongKong))
-                .toLineProtocol()
+        let pointUTC = try InfluxDBClient.Point(
+            "h2o",
+            fields: ["val": .int(1)],
+            time: .date(utc)
+        ).toLineProtocol()
+        let pointHK = try InfluxDBClient.Point(
+            "h2o",
+            fields: ["val": .int(1)],
+            time: .date(hongKong)
+        ).toLineProtocol()
+
         XCTAssertEqual(pointUTC, pointHK)
     }
 
@@ -339,24 +414,6 @@ final class PointTests: XCTestCase {
                             time: .date(Date(2020, 10, 11, 0, 0, 0, 0))
                     ),
                     "h2o_feet water_level=1.0 1602374400000000000"
-            ),
-            (
-                    (
-                            measurement: "h2o_feet",
-                            tags: ["location": nil],
-                            fields: ["water_level": .double(1.0)],
-                            time: .date(Date(2020, 10, 11, 0, 0, 0, 0))
-                    ),
-                    "h2o_feet water_level=1.0 1602374400000000000"
-            ),
-            (
-                    (
-                            measurement: "h2o_feet",
-                            tags: ["location": nil],
-                            fields: ["water_level": .double(1.0)],
-                            time: nil
-                    ),
-                    "h2o_feet water_level=1.0"
             )
         ]
 
@@ -400,21 +457,25 @@ final class PointTests: XCTestCase {
     }
 
     func testDescription() throws {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "loc", value: "us")
-                .addField(key: "value", value: .int(100))
-
-        let required = "Point: measurement:h2o, tags:[\"loc\": Optional(\"us\")], "
-                + "fields:[\"value\": Optional(InfluxDBSwift.InfluxDBClient.Point.FieldValue.int(100))], time:nil"
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: ["loc": "us"],
+            fields: ["value": .int(100)]
+        )
+        let required = "Point: measurement:h2o, tags:[\"loc\": \"us\"], "
+                + "fields:[\"value\": InfluxDBSwift.InfluxDBClient.Point.FieldValue.int(100)], time:nil"
         XCTAssertEqual(required, point.description)
     }
 
     func testDefaultTags() throws {
-        let point = InfluxDBClient.Point("h2o")
-                .addTag(key: "loc", value: "us")
-                .addTag(key: "in_default_tags", value: "use_this")
-                .addField(key: "value", value: .int(100))
-
+        let point = InfluxDBClient.Point(
+            "h2o",
+            tags: [
+                "loc": "us",
+                "in_default_tags": "use_this"
+            ],
+            fields: ["value": .int(100)]
+        )
         let defaultTags = ["tag_a_key": "tag_a_value", "in_default_tags": "not_use_this", "a_tag": "a_tag_value"]
 
         XCTAssertEqual(
@@ -463,9 +524,11 @@ final class PointTests: XCTestCase {
         ]
 
         try expectations.forEach { expectation in
-            let point = InfluxDBClient.Point("h2o")
-                    .addField(key: "level", value: .int(1))
-                    .time(time: expectation.time)
+            let point = InfluxDBClient.Point(
+                "h2o",
+                fields: ["level": .int(1)],
+                time: expectation.time
+            )
 
             XCTAssertEqual(expectation.records[0], try point.toLineProtocol(precision: .ns))
             XCTAssertEqual(expectation.records[1], try point.toLineProtocol(precision: .us))

--- a/Tests/InfluxDBSwiftTests/WriteAPITests.swift
+++ b/Tests/InfluxDBSwiftTests/WriteAPITests.swift
@@ -63,9 +63,12 @@ final class WriteAPITests: XCTestCase {
 
         MockURLProtocol.handler = simpleWriteHandler(expectation: expectation)
 
-        let point = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(1))
+        let point = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(1)]
+        )
+
         client.makeWriteAPI().write(point: point) { response, error in
             if let error = error {
                 XCTFail("Error occurs: \(error)")
@@ -97,14 +100,19 @@ final class WriteAPITests: XCTestCase {
             return (response, Data())
         }
 
-        let point1 = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(1))
-                .time(time: .interval(1, .s))
-        let point2 = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "b")
-                .addField(key: "value", value: .int(2))
-                .time(time: .interval(2, .ns))
+        let point1 = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(1)],
+            time: .interval(1, .s)
+        )
+
+        let point2 = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "b"],
+            fields: ["value": .int(2)],
+            time: .interval(2, .ns)
+        )
 
         client.makeWriteAPI().write(points: [point1, point2]) { _, _ in
             expectation.fulfill()
@@ -135,12 +143,18 @@ final class WriteAPITests: XCTestCase {
             return (response, Data())
         }
 
-        let point1 = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(1))
-        let point2 = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "b")
-                .addField(key: "value", value: .int(2))
+        let point1 = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(1)]
+        )
+
+        let point2 = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "b"],
+            fields: ["value": .int(2)]
+        )
+
         client.makeWriteAPI().write(points: [point1, point2]) { response, error in
             if let error = error {
                 XCTFail("Error occurs: \(error)")
@@ -236,9 +250,12 @@ final class WriteAPITests: XCTestCase {
                 fields: ["value": .int(3)],
                 time: .interval(3)
         )
-        let point = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(2))
+
+        let point = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(2)]
+        )
 
         client.makeWriteAPI().write(records: [record]) { _, error in
             if let error = error {
@@ -391,9 +408,12 @@ final class WriteAPITests: XCTestCase {
         }
 
         let record = "mem,tag=a value=1"
-        let point = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(2))
+        let point = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(2)]
+        )
+
         let tuple: InfluxDBClient.Point.Tuple
                 = (measurement: "mem", tags: ["tag": "a"], fields: ["value": .int(3)], time: nil)
 
@@ -456,9 +476,11 @@ final class WriteAPITests: XCTestCase {
         // record
         try await client.makeWriteAPI().write(record: "mem,tag=a value=1i")
         // point
-        let point = InfluxDBClient.Point("mem")
-                .addTag(key: "tag", value: "a")
-                .addField(key: "value", value: .int(1))
+        let point = InfluxDBClient.Point(
+            "mem",
+            tags: ["tag": "a"],
+            fields: ["value": .int(1)]
+        )
         try await client.makeWriteAPI().write(point: point)
         // tuple
         let tuple: InfluxDBClient.Point.Tuple = (

--- a/Tests/InfluxDBSwiftTests/XCTestManifests.swift
+++ b/Tests/InfluxDBSwiftTests/XCTestManifests.swift
@@ -105,7 +105,6 @@ extension PointTests {
         ("testDescription", testDescription),
         ("testEqualSignEscaping", testEqualSignEscaping),
         ("testFieldEscape", testFieldEscape),
-        ("testFieldNullValue", testFieldNullValue),
         ("testFieldTypes", testFieldTypes),
         ("testFromTuple", testFromTuple),
         ("testInfinityValues", testInfinityValues),


### PR DESCRIPTION
Closes #69, closes #70

## Proposed Changes

Updated `Point` to be a sendable struct.

Deprecated addTag(key:value:), addField(key:value:), and time(time:) in favor of using the mutable properties.

Added mutating versions of addTag(key:value:), addField(key:value:), and time(time:) for use when the result is discarded. This is to try and minimize the number of complication errors introduced with this change. The following warnings will be produced in the following use cases.

Calling init and mutating functions in the same statement
```swift
let point = InfluxDBClient.Point("p")
    .addTag(key: "t1", value: "a")
    .addTag(key: "t2", value: "b")
     `- warning: 'point.addTag(key:value:)' is deprecated: Pass tags to Point.init or use the tags property
``` 

Calling init and mutating functions in separate statements
```swift
let point = InfluxDBClient.Point("p")

point
    .addTag(key: "t1", value: "a")
     `- warning: 'change()' is deprecated: Pass tags to Point.init or use the tags property
    .addTag(key: "t2", value: "b")
     `- warning: 'point.addTag(key:value:)' is deprecated: Pass tags to Point.init or use the tags property
     `- warning: result of call to 'change()' is unused
``` 

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `swift test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
